### PR TITLE
refresh claims only when not in bearer mode

### DIFF
--- a/src/KeycloakIdentityModel/KeycloakIdentity.cs
+++ b/src/KeycloakIdentityModel/KeycloakIdentity.cs
@@ -436,8 +436,8 @@ namespace KeycloakIdentityModel
             await _refreshLock.WaitAsync();
             try
             {
-                // Check to update cached claims
-                if (_kcClaims == null || _accessToken.ValidTo <= DateTime.Now)
+                // Check to update cached claims, but not if refresh token is missing (as in bearer mode)
+                if ((_kcClaims == null || _accessToken.ValidTo <= DateTime.Now) && _refreshToken != null)
                 {
                     // Validate refresh token expiration
                     if (_refreshToken.ValidTo <= DateTime.Now)


### PR DESCRIPTION
I was experimenting with bearer tokens and set the TokenClockSkew to a very high number for testing purposes. This lead to a situation where the bearer token was accepted as valid in one place, but then it tried to refresh the access token and failed. TokenClockSkew is not checked in this piece of code that I have now changed. 

This will also happen in production, but only less frequently when the TokenClockSkew is set to a reasonably small number. Therefore I decided to change the code.

I think that the library shouldn't try to do any refresh when there is no refresh token. A missing refresh token would indicate that we are operating in bearer token mode. 

Please review and comment.