### PR TITLE
map global realm roles to claim

### DIFF
--- a/src/KeycloakIdentityModel/Utilities/ClaimMapping/ClaimMappings.cs
+++ b/src/KeycloakIdentityModel/Utilities/ClaimMapping/ClaimMappings.cs
@@ -63,6 +63,11 @@ namespace KeycloakIdentityModel.Utilities.ClaimMapping
             {
                 ClaimName = ClaimTypes.Role,
                 JSelectQuery = "resource_access.{gid}.roles"
+            },
+            new ClaimLookup
+            {
+                ClaimName = ClaimTypes.Role,
+                JSelectQuery = "realm_access.roles"
             }
         };
 


### PR DESCRIPTION
I have some global realm roles, see JWT excerpt below. I found that Keycloak Owin did not map them. This is the code I needed to add to make it working.

Both types of roles are mapped to `ClaimTypes.Role`. This works for me, but I don't know if there is a better possibility to do this.

Best regards,
Alexander

```
{
...
  "realm_access": {
    "roles": [
      "my-role-1",
      "my-role-2"
    ]
  },
...
}
```